### PR TITLE
feat(make):upgrade make command

### DIFF
--- a/IceFireDB-PubSub/Makefile
+++ b/IceFireDB-PubSub/Makefile
@@ -10,12 +10,15 @@ COMMIT_HASH=$(shell git rev-parse --short HEAD || echo "GitNotFound")
 BUILD_DATE=$(shell date '+%Y-%m-%d %H:%M:%S')
 # compile
 CFLAGS = -ldflags "-s -w -X \"main.BuildVersion=${COMMIT_HASH}\""
+# GOOS 方便在Mac系统上快速的进行调试开发
+GOOS = $(shell uname | tr 'A-Z' 'a-z')
+# GOARCH 考虑到目前大部分机器为 64 的指令集，暂不对此进行处理
 
 all:
 	if [ ! -d "./bin/" ]; then \
 	mkdir bin; \
 	fi
-	GOPROXY=$(GOPROXY) GOOS=linux GOARCH=amd64 go build $(CFLAGS) -o $(PROG) $(SRCS)
+	GOPROXY=$(GOPROXY) GOOS=$(GOOS) GOARCH=amd64 go build $(CFLAGS) -o $(PROG) $(SRCS)
 
 # Compiling the RACE version
 race:

--- a/IceFireDB-PubSub/Makefile
+++ b/IceFireDB-PubSub/Makefile
@@ -10,9 +10,17 @@ COMMIT_HASH=$(shell git rev-parse --short HEAD || echo "GitNotFound")
 BUILD_DATE=$(shell date '+%Y-%m-%d %H:%M:%S')
 # compile
 CFLAGS = -ldflags "-s -w -X \"main.BuildVersion=${COMMIT_HASH}\""
-# GOOS 方便在Mac系统上快速的进行调试开发
-GOOS = $(shell uname | tr 'A-Z' 'a-z')
-# GOARCH 考虑到目前大部分机器为 64 的指令集，暂不对此进行处理
+# Get GOOS from System
+LOCAL_OS := $(shell uname)
+ifeq ($(LOCAL_OS),Linux)
+   TARGET_OS_LOCAL = linux
+else ifeq ($(LOCAL_OS),Darwin)
+   TARGET_OS_LOCAL = darwin
+else
+   TARGET_OS_LOCAL = windows
+   PROTOC_GEN_GO_NAME := "icefiredb.exe"
+endif
+export GOOS ?= $(TARGET_OS_LOCAL)
 
 all:
 	if [ ! -d "./bin/" ]; then \


### PR DESCRIPTION
In the MacOS operating system, we need to manually modify the value of GOOS to compile, which is not enough to traverse. Using uname in Unix to automatically obtain the value of GOOS, so we can directly perform the Make operation.

Good Luck.