### PR TITLE
feat(sqlite): add P2P node options for  node_host_ip  and node_host_port

### DIFF
--- a/IceFireDB-SQLite/config/config.yaml
+++ b/IceFireDB-SQLite/config/config.yaml
@@ -5,7 +5,7 @@ sqlite:
   filename: "db/sqlite.db"
 
 debug:  # Control to open pprof
-  enable: true
+  enable: false
   port: 17878
 
 # p2p config
@@ -14,6 +14,8 @@ p2p:
   service_discovery_id: "p2p_sqlite_service"
   service_command_topic: "p2p_sqlite_service_topic"
   service_discover_mode: "advertise" # advertise or announce
+  node_host_ip: "127.0.0.1" #local ipv4 ip
+  node_host_port: 0 # any port 
 
 # Tenant list
 userlist:

--- a/IceFireDB-SQLite/internal/sqlite/db.go
+++ b/IceFireDB-SQLite/internal/sqlite/db.go
@@ -31,7 +31,10 @@ func InitSQLite(ctx context.Context, filename string) *sql.DB {
 	}
 	if config.Get().P2P.Enable {
 		// create p2p element
-		p2pHost = p2p.NewP2P(config.Get().P2P.ServiceDiscoveryID) // create p2p
+		p2pHost = p2p.NewP2P(config.Get().P2P.ServiceDiscoveryID,
+			config.Get().P2P.NodeHostIP,
+			config.Get().P2P.NodeHostPort)
+
 		logrus.Info("Completed P2P Setup")
 
 		// Connect to peers with the chosen discovery method
@@ -46,7 +49,7 @@ func InitSQLite(ctx context.Context, filename string) *sql.DB {
 
 		logrus.Info("Connected to P2P Service Peers")
 		var err error
-		p2pPubSub, err = p2p.JoinPubSub(p2pHost, "mysql-client", config.Get().P2P.ServiceCommandTopic)
+		p2pPubSub, err = p2p.JoinPubSub(p2pHost, "icefiredb-sqlite-client", config.Get().P2P.ServiceCommandTopic)
 		if err != nil {
 			panic(err)
 		}

--- a/IceFireDB-SQLite/main.go
+++ b/IceFireDB-SQLite/main.go
@@ -3,15 +3,16 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/IceFireDB/IceFireDB-SQLite/internal/mysql"
-	"github.com/IceFireDB/IceFireDB-SQLite/pkg/config"
-	"github.com/sirupsen/logrus"
-	"github.com/urfave/cli"
 	"log"
 	"os"
 	"os/signal"
 	"syscall"
 	"time"
+
+	"github.com/IceFireDB/IceFireDB-SQLite/internal/mysql"
+	"github.com/IceFireDB/IceFireDB-SQLite/pkg/config"
+	"github.com/sirupsen/logrus"
+	"github.com/urfave/cli"
 )
 
 func main() {
@@ -75,13 +76,13 @@ func exitSignal(cancel context.CancelFunc, stop chan struct{}) error {
 
 			select {
 			case <-stop:
-				fmt.Println("shutdown！！！！")
+				fmt.Println("shutdown")
 			case <-time.After(time.Second * 5):
-				fmt.Println("timeout forced exit！！！！")
+				fmt.Println("timeout forced shutdown")
 			}
 			os.Exit(0)
 		case syscall.SIGHUP:
-			fmt.Println("+++++++++++++++++++++++++++++")
+			fmt.Println("catch syscall.SIGHUP")
 		}
 	}
 	return nil

--- a/IceFireDB-SQLite/pkg/config/config.go
+++ b/IceFireDB-SQLite/pkg/config/config.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"net"
+
 	"github.com/spf13/viper"
 )
 
@@ -35,6 +37,8 @@ type P2PS struct {
 	ServiceDiscoveryID  string `mapstructure:"service_discovery_id" json:"service_discovery_id"`
 	ServiceCommandTopic string `mapstructure:"service_command_topic" json:"service_command_topic"`
 	ServiceDiscoverMode string `mapstructure:"service_discover_mode" json:"service_discover_mode"`
+	NodeHostIP          string `mapstructure:"node_host_ip" json:"node_host_ip"`
+	NodeHostPort        int    `mapstructure:"node_host_port" json:"node_host_port"`
 }
 
 func init() {
@@ -52,6 +56,14 @@ func InitConfig(path string) {
 	err := viper.Unmarshal(defaultConfig)
 	if err != nil {
 		panic(err)
+	}
+
+	if net.ParseIP(defaultConfig.P2P.NodeHostIP) == nil {
+		defaultConfig.P2P.NodeHostIP = "0.0.0.0"
+	}
+
+	if defaultConfig.P2P.NodeHostPort < 0 || defaultConfig.P2P.NodeHostPort > 65535 {
+		defaultConfig.P2P.NodeHostPort = 0
 	}
 }
 

--- a/IceFireDB-SQLite/pkg/p2p/pubsub.go
+++ b/IceFireDB-SQLite/pkg/p2p/pubsub.go
@@ -12,7 +12,7 @@ import (
 // Represents the default fallback room and user names
 // if they aren't provided when the app is started
 const defaultclient = "client"
-const defaulttopic = "pubsub"
+const defaulttopic = "icefiredb-sqlite-pubsub"
 
 // A structure that represents a PubSub Chat Room
 type PubSub struct {
@@ -65,7 +65,7 @@ func (c chatlog) String() string {
 func JoinPubSub(p2phost *P2P, clientName string, topicName string) (*PubSub, error) {
 
 	// Create a PubSub topic with the room name
-	topic, err := p2phost.PubSub.Join(fmt.Sprintf("pub-sub-p2p-%s", topicName))
+	topic, err := p2phost.PubSub.Join(fmt.Sprintf("icefiredb-sqlite-pub-sub-p2p-%s", topicName))
 	// Check the error
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This pull request introduces support for SQLite P2P node options, specifically adding `node_host_ip` and `node_host_port` to enhance P2P networking capabilities.

- Added `node_host_ip` and `node_host_port` options to the P2P configuration in the SQLite settings.
- Updated the relevant parts of the code to handle and utilize these new options for P2P communication.
- Modified the documentation to include details about the newly added P2P node options.

## Motivation and Context
In order to facilitate more flexible P2P networking with SQLite, this PR introduces two essential options: `node_host_ip` for specifying the local IPv4 address and `node_host_port` for selecting any available port. These options provide users with greater control over the P2P configuration based on their specific requirements.

## Configuration Example
```yaml
p2p:
  enable: true
  service_discovery_id: "p2p_sqlite_service"
  service_command_topic: "p2p_sqlite_service_topic"
  service_discover_mode: "advertise" # advertise or announce
  node_host_ip: "127.0.0.1" # local IPv4 IP
  node_host_port: 0 # any available port
