### PR TITLE
feat(p2p):support  p2p node options

### DIFF
--- a/IceFireDB-PubSub/config/config.yaml
+++ b/IceFireDB-PubSub/config/config.yaml
@@ -11,6 +11,8 @@ p2p:
   service_discovery_id: "p2p_redis_proxy_service_test"
   service_command_topic: "p2p_redis_proxy_service_topic_test"
   service_discover_mode: "advertise" # advertise or announce
+  node_host_ip: "127.0.0.1" #local ipv4 ip
+  node_host_port: 0 # any port 
 
 # remote redis config
 redisdb:

--- a/IceFireDB-PubSub/go.mod
+++ b/IceFireDB-PubSub/go.mod
@@ -3,7 +3,7 @@ module github.com/IceFireDB/IceFireDB/IceFireDB-PubSub
 go 1.16
 
 require (
-	github.com/IceFireDB/components-go v1.0.1
+	github.com/IceFireDB/components-go v1.0.3
 	github.com/alicebob/miniredis/v2 v2.17.0
 	github.com/chasex/redis-go-cluster v1.0.0
 	github.com/gomodule/redigo v1.8.8

--- a/IceFireDB-PubSub/go.sum
+++ b/IceFireDB-PubSub/go.sum
@@ -45,8 +45,8 @@ github.com/AndreasBriese/bbloom v0.0.0-20190825152654-46b345b51c96/go.mod h1:bOv
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/IceFireDB/components-go v1.0.1 h1:+m6JhvYQOvuzafN+CoWQbItRhRsei/DtP5Hd+yWNYeA=
-github.com/IceFireDB/components-go v1.0.1/go.mod h1:wvlQyZdtqgKhzM/IRLLOlAqpdFlmItKboLNDXLaI0R0=
+github.com/IceFireDB/components-go v1.0.3 h1:IEVMMUgWyJ1ej7EZp2QtnaXvFVsRVZm+kKUg3Y4KPpc=
+github.com/IceFireDB/components-go v1.0.3/go.mod h1:wvlQyZdtqgKhzM/IRLLOlAqpdFlmItKboLNDXLaI0R0=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
 github.com/Kubuxu/go-os-helper v0.0.1/go.mod h1:N8B+I7vPCT80IcP58r50u4+gEEcsZETFUpAzWW2ep1Y=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=

--- a/IceFireDB-PubSub/pkg/config/config.go
+++ b/IceFireDB-PubSub/pkg/config/config.go
@@ -21,6 +21,7 @@ package config
 
 import (
 	"errors"
+	"net"
 	"strings"
 
 	rediscluster "github.com/chasex/redis-go-cluster"
@@ -55,6 +56,14 @@ func InitConfig() error {
 	}
 	if _config.IgnoreCMD.Enable && len(_config.IgnoreCMD.CMDList) > 0 {
 		CmdToUpper(_config.IgnoreCMD.CMDList)
+	}
+
+	if net.ParseIP(_config.P2P.NodeHostIP) == nil {
+		_config.P2P.NodeHostIP = "0.0.0.0"
+	}
+
+	if _config.P2P.NodeHostPort < 0 || _config.P2P.NodeHostPort > 65535 {
+		_config.P2P.NodeHostPort = 0
 	}
 	return nil
 }

--- a/IceFireDB-PubSub/pkg/config/types.go
+++ b/IceFireDB-PubSub/pkg/config/types.go
@@ -36,6 +36,8 @@ type P2PS struct {
 	ServiceDiscoveryID  string `mapstructure:"service_discovery_id" json:"service_discovery_id"`
 	ServiceCommandTopic string `mapstructure:"service_command_topic" json:"service_command_topic"`
 	ServiceDiscoverMode string `mapstructure:"service_discover_mode" json:"service_discover_mode"`
+	NodeHostIP          string `mapstructure:"node_host_ip" json:"node_host_ip"`
+	NodeHostPort        int    `mapstructure:"node_host_port" json:"node_host_port"`
 }
 
 type ProxyS struct {

--- a/IceFireDB-PubSub/proxy/proxy.go
+++ b/IceFireDB-PubSub/proxy/proxy.go
@@ -94,7 +94,7 @@ func New() (*Proxy, error) {
 	if config.Get().P2P.Enable {
 		logrus.Println("Starting Pubsub ...")
 		// create p2p element
-		p2phost := p2p.NewP2P(config.Get().P2P.ServiceDiscoveryID) // create p2p
+		p2phost := p2p.NewP2P(config.Get().P2P.ServiceDiscoveryID, config.Get().P2P.NodeHostIP, config.Get().P2P.NodeHostPort) // create p2p
 		p.P2pHost = p2phost
 
 		logrus.Println("Completed P2P Setup")

--- a/IceFireDB-Redis-Proxy/cmd/proxy/main.go
+++ b/IceFireDB-Redis-Proxy/cmd/proxy/main.go
@@ -104,13 +104,13 @@ func start(c *cli.Context) error {
 			}()
 			select {
 			case <-ok:
-				logrus.Info("shutdown proxy ！！！！")
+				logrus.Info("shutdown proxy")
 			case <-time.After(time.Second * 5):
-				logrus.Info("context deadline exceeded ！！！！")
+				logrus.Info("context deadline exceeded")
 			}
 			os.Exit(0)
 		case syscall.SIGHUP:
-			logrus.Info("+++++++++++++++++++++++++++++")
+			logrus.Info("catch syscall.SIGHUP")
 		}
 	}
 	return nil

--- a/IceFireDB-Redis-Proxy/config/config.yaml
+++ b/IceFireDB-Redis-Proxy/config/config.yaml
@@ -11,6 +11,8 @@ p2p:
   service_discovery_id: "p2p_redis_proxy_service_test"
   service_command_topic: "p2p_redis_proxy_service_topic_test"
   service_discover_mode: "advertise" # advertise or announce
+  node_host_ip: "127.0.0.1" #local ipv4 ip
+  node_host_port: 0 # any port 
 
 # remote redis config
 redisdb:

--- a/IceFireDB-Redis-Proxy/go.mod
+++ b/IceFireDB-Redis-Proxy/go.mod
@@ -3,7 +3,7 @@ module github.com/IceFireDB/IceFireDB/IceFireDB-Redis-Proxy
 go 1.16
 
 require (
-	github.com/IceFireDB/components-go v1.0.1
+	github.com/IceFireDB/components-go v1.0.2
 	github.com/alicebob/miniredis/v2 v2.17.0
 	github.com/chasex/redis-go-cluster v1.0.0
 	github.com/gomodule/redigo v1.8.8

--- a/IceFireDB-Redis-Proxy/go.mod
+++ b/IceFireDB-Redis-Proxy/go.mod
@@ -3,7 +3,7 @@ module github.com/IceFireDB/IceFireDB/IceFireDB-Redis-Proxy
 go 1.16
 
 require (
-	github.com/IceFireDB/components-go v1.0.2
+	github.com/IceFireDB/components-go v1.0.3
 	github.com/alicebob/miniredis/v2 v2.17.0
 	github.com/chasex/redis-go-cluster v1.0.0
 	github.com/gomodule/redigo v1.8.8

--- a/IceFireDB-Redis-Proxy/go.sum
+++ b/IceFireDB-Redis-Proxy/go.sum
@@ -45,8 +45,8 @@ github.com/AndreasBriese/bbloom v0.0.0-20190825152654-46b345b51c96/go.mod h1:bOv
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/IceFireDB/components-go v1.0.1 h1:+m6JhvYQOvuzafN+CoWQbItRhRsei/DtP5Hd+yWNYeA=
-github.com/IceFireDB/components-go v1.0.1/go.mod h1:wvlQyZdtqgKhzM/IRLLOlAqpdFlmItKboLNDXLaI0R0=
+github.com/IceFireDB/components-go v1.0.3 h1:IEVMMUgWyJ1ej7EZp2QtnaXvFVsRVZm+kKUg3Y4KPpc=
+github.com/IceFireDB/components-go v1.0.3/go.mod h1:wvlQyZdtqgKhzM/IRLLOlAqpdFlmItKboLNDXLaI0R0=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
 github.com/Kubuxu/go-os-helper v0.0.1/go.mod h1:N8B+I7vPCT80IcP58r50u4+gEEcsZETFUpAzWW2ep1Y=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=

--- a/IceFireDB-Redis-Proxy/pkg/config/config.go
+++ b/IceFireDB-Redis-Proxy/pkg/config/config.go
@@ -21,6 +21,7 @@ package config
 
 import (
 	"errors"
+	"net"
 	"strings"
 
 	rediscluster "github.com/chasex/redis-go-cluster"
@@ -55,6 +56,14 @@ func InitConfig() error {
 	}
 	if _config.IgnoreCMD.Enable && len(_config.IgnoreCMD.CMDList) > 0 {
 		CmdToUpper(_config.IgnoreCMD.CMDList)
+	}
+
+	if net.ParseIP(_config.P2P.NodeHostIP) == nil {
+		_config.P2P.NodeHostIP = "0.0.0.0"
+	}
+
+	if _config.P2P.NodeHostPort < 0 || _config.P2P.NodeHostPort > 65535 {
+		_config.P2P.NodeHostPort = 0
 	}
 
 	return nil

--- a/IceFireDB-Redis-Proxy/pkg/config/types.go
+++ b/IceFireDB-Redis-Proxy/pkg/config/types.go
@@ -36,6 +36,8 @@ type P2PS struct {
 	ServiceDiscoveryID  string `mapstructure:"service_discovery_id" json:"service_discovery_id"`
 	ServiceCommandTopic string `mapstructure:"service_command_topic" json:"service_command_topic"`
 	ServiceDiscoverMode string `mapstructure:"service_discover_mode" json:"service_discover_mode"`
+	NodeHostIP          string `mapstructure:"node_host_ip" json:"node_host_ip"`
+	NodeHostPort        int    `mapstructure:"node_host_port" json:"node_host_port"`
 }
 
 type ProxyS struct {

--- a/IceFireDB-Redis-Proxy/proxy/proxy.go
+++ b/IceFireDB-Redis-Proxy/proxy/proxy.go
@@ -90,7 +90,7 @@ func New() (*Proxy, error) {
 	// if enable p2p command pubsub mode,then create p2p pubsub handle
 	if config.Get().P2P.Enable {
 		// create p2p element
-		p2phost := p2p.NewP2P(config.Get().P2P.ServiceDiscoveryID) // create p2p
+		p2phost := p2p.NewP2P(config.Get().P2P.ServiceDiscoveryID, config.Get().P2P.NodeHostIP, config.Get().P2P.NodeHostPort)
 		p.P2pHost = p2phost
 
 		log.Println("Completed P2P Setup")

--- a/IceFireDB-Redis-Proxy/proxy/proxy.go
+++ b/IceFireDB-Redis-Proxy/proxy/proxy.go
@@ -107,7 +107,7 @@ func New() (*Proxy, error) {
 
 		log.Println("Connected to P2P Service Peers")
 
-		p.P2pSubPub, err = p2p.JoinPubSub(p.P2pHost, "redis-client", config.Get().P2P.ServiceCommandTopic)
+		p.P2pSubPub, err = p2p.JoinPubSub(p.P2pHost, "icefiredb-redis-proxy-client", config.Get().P2P.ServiceCommandTopic)
 
 		if err != nil {
 			log.Println(err)

--- a/IceFireDB-SQLProxy/config/config.yaml
+++ b/IceFireDB-SQLProxy/config/config.yaml
@@ -26,3 +26,5 @@ p2p:
   service_discovery_id: "p2p_sqlproxy_service_test"
   service_command_topic: "p2p_sqlproxy_service_topic_test"
   service_discover_mode: "advertise" # advertise or announce
+  node_host_ip: "127.0.0.1" #local ipv4 ip
+  node_host_port: 0 # any port 

--- a/IceFireDB-SQLProxy/internal/mysql/p2p.go
+++ b/IceFireDB-SQLProxy/internal/mysql/p2p.go
@@ -1,13 +1,14 @@
 package mysql
 
 import (
+	"strings"
+	"time"
+
 	"github.com/IceFireDB/IceFireDB-SQLProxy/pkg/config"
 	"github.com/IceFireDB/IceFireDB-SQLProxy/pkg/mysql/client"
 	"github.com/IceFireDB/IceFireDB-SQLProxy/pkg/p2p"
 	"github.com/IceFireDB/IceFireDB-SQLProxy/utils"
 	"github.com/sirupsen/logrus"
-	"strings"
-	"time"
 )
 
 var (
@@ -17,7 +18,7 @@ var (
 
 func initP2P(m *mysqlProxy) {
 	// create p2p element
-	p2pHost = p2p.NewP2P(config.Get().P2P.ServiceDiscoveryID) // create p2p
+	p2pHost = p2p.NewP2P(config.Get().P2P.ServiceDiscoveryID, config.Get().P2P.NodeHostIP, config.Get().P2P.NodeHostPort) // create p2p
 	logrus.Info("Completed P2P Setup")
 	// Connect to peers with the chosen discovery method
 	switch strings.ToLower(config.Get().P2P.ServiceDiscoverMode) {

--- a/IceFireDB-SQLProxy/pkg/config/config.go
+++ b/IceFireDB-SQLProxy/pkg/config/config.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"net"
+
 	"github.com/spf13/viper"
 )
 
@@ -41,6 +43,8 @@ type P2PS struct {
 	ServiceDiscoveryID  string `json:"service_discovery_id"`
 	ServiceCommandTopic string `json:"service_command_topic"`
 	ServiceDiscoverMode string `json:"service_discover_mode"`
+	NodeHostIP          string `json:"node_host_ip"`
+	NodeHostPort        int    `json:"node_host_port"`
 }
 
 func init() {
@@ -58,6 +62,14 @@ func InitConfig(path string) {
 	err := viper.Unmarshal(defaultConfig)
 	if err != nil {
 		panic(err)
+	}
+
+	if net.ParseIP(defaultConfig.P2P.NodeHostIP) == nil {
+		defaultConfig.P2P.NodeHostIP = "0.0.0.0"
+	}
+
+	if defaultConfig.P2P.NodeHostPort < 0 || defaultConfig.P2P.NodeHostPort > 65535 {
+		defaultConfig.P2P.NodeHostPort = 0
 	}
 }
 

--- a/IceFireDB-SQLProxy/pkg/p2p/p2p.go
+++ b/IceFireDB-SQLProxy/pkg/p2p/p2p.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"crypto/sha256"
+	"fmt"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -57,27 +58,27 @@ A Kademlia DHT is then bootstrapped on this host using the default peers offered
 and a Peer Discovery service is created from this Kademlia DHT. The PubSub handler is then
 created on the host using the peer discovery service created prior.
 */
-func NewP2P(serviceName string) *P2P {
+func NewP2P(serviceName string, nodeHostIP string, nodeHostPort int) *P2P {
 	// Setup a background context
 	ctx := context.Background()
 
-	// Setup a P2P Host Node :p2p host
-	nodehost, kaddht := setupHost(ctx)
+	// Setup a P2P Host Node
+	nodehost, kaddht := setupHost(ctx, nodeHostIP, nodeHostPort)
 	// Debug log
-	logrus.Debugln("Created the P2P Host and the Kademlia DHT.")
+	logrus.Infoln("Setup the p2p host,listen on", nodehost.Addrs())
 
-	// Bootstrap the Kad DHT :HT
+	// Bootstrap the Kad DHT
 	bootstrapDHT(ctx, nodehost, kaddht)
 
 	// Debug log
 	logrus.Debugln("Bootstrapped the Kademlia DHT and Connected to Bootstrap Peers")
 
-	// Create a peer discovery service using the Kad DHT :
+	// Create a peer discovery service using the Kad DHT
 	routingdiscovery := discoveryRouting.NewRoutingDiscovery(kaddht)
 	// Debug log
 	logrus.Debugln("Created the Peer Discovery Service.")
 
-	// Create a PubSub handler with the routing discovery：ubSub
+	// Create a PubSub handler with the routing discovery PubSu
 	pubsubhandler := setupPubSub(ctx, nodehost, routingdiscovery)
 	// Debug log
 	logrus.Debugln("Created the PubSub Handler.")
@@ -102,7 +103,7 @@ func (p2p *P2P) AdvertiseConnect() {
 	// Advertise the availabilty of the service on this node
 	ttl, err := p2p.Discovery.Advertise(p2p.Ctx, p2p.service)
 	// Debug log
-	logrus.Debugln("Advertised the PeerChat Service.")
+	logrus.Debugln("Advertised the p2p Service.")
 	// Sleep to give time for the advertisment to propogate
 	time.Sleep(time.Second * 5)
 	// Debug log
@@ -117,7 +118,7 @@ func (p2p *P2P) AdvertiseConnect() {
 		}).Fatalln("P2P Peer Discovery Failed!")
 	}
 	// Trace log
-	logrus.Traceln("Discovered PeerChat Service Peers.")
+	logrus.Traceln("Discovered p2p Service Peers.")
 
 	// Connect to peers as they are discovered
 	go handlePeerDiscovery(p2p.Host, peerchan)
@@ -145,14 +146,14 @@ func (p2p *P2P) AnnounceConnect() {
 		}).Fatalln("Failed to Announce Service CID!")
 	}
 	// Debug log
-	logrus.Debugln("Announced the PeerChat Service.")
+	logrus.Debugln("Announced the p2p Service.")
 	// Sleep to give time for the advertisment to propogate
 	time.Sleep(time.Second * 5)
 
 	// Find the other providers for the service CID
 	peerchan := p2p.KadDHT.FindProvidersAsync(p2p.Ctx, cidvalue, 0)
 	// Trace log
-	logrus.Traceln("Discovered PeerChat Service Peers.")
+	logrus.Traceln("Discovered p2p Service Peers.")
 
 	// Connect to peers as they are discovered
 	go handlePeerDiscovery(p2p.Host, peerchan)
@@ -162,7 +163,7 @@ func (p2p *P2P) AnnounceConnect() {
 
 // A function that generates the p2p configuration options and creates a
 // libp2p host object for the given context. The created host is returned
-func setupHost(ctx context.Context) (host.Host, *dht.IpfsDHT) {
+func setupHost(ctx context.Context, nodeHostIP string, nodeHostPort int) (host.Host, *dht.IpfsDHT) {
 	// Set up the host identity options
 	prvkey, pubkey, err := crypto.GenerateKeyPairWithReader(crypto.RSA, 2048, rand.Reader)
 
@@ -194,8 +195,16 @@ func setupHost(ctx context.Context) (host.Host, *dht.IpfsDHT) {
 	// Trace log
 	logrus.Traceln("Generated P2P Security and Transport Configurations.")
 
+	multiaddrStr := "/ip4/%s/tcp/%d"
+
+	//default "/ip4/0.0.0.0/tcp/0"
+	multiaddrStr = fmt.Sprintf(multiaddrStr, nodeHostIP, nodeHostPort)
+
 	// Set up host listener address options
-	muladdr, err := multiaddr.NewMultiaddr("/ip4/0.0.0.0/tcp/0")
+	muladdr, err := multiaddr.NewMultiaddr(multiaddrStr)
+
+	logrus.Infoln("Setup Multiaddr", multiaddrStr)
+
 	listen := libp2p.ListenAddrs(muladdr)
 	// Handle any potential error
 	if err != nil {

--- a/IceFireDB-SQLProxy/pkg/p2p/pubsub.go
+++ b/IceFireDB-SQLProxy/pkg/p2p/pubsub.go
@@ -12,7 +12,7 @@ import (
 // Represents the default fallback room and user names
 // if they aren't provided when the app is started
 const defaultclient = "client"
-const defaulttopic = "pubsub"
+const defaulttopic = "icefiredb-sqlproxy-pubsub"
 
 // A structure that represents a PubSub Chat Room
 type PubSub struct {
@@ -65,7 +65,7 @@ func (c chatlog) String() string {
 func JoinPubSub(p2phost *P2P, clientName string, topicName string) (*PubSub, error) {
 
 	// Create a PubSub topic with the room name
-	topic, err := p2phost.PubSub.Join(fmt.Sprintf("pub-sub-p2p-%s", topicName))
+	topic, err := p2phost.PubSub.Join(fmt.Sprintf("icefiredb-sqlproxy-pub-sub-p2p-%s", topicName))
 	// Check the error
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This pull request introduces support for P2P node options, specifically adding `node_host_ip` and `node_host_port` to enhance P2P networking capabilities.

- Added `node_host_ip` and `node_host_port` options to the P2P configuration in the P2P settings.
- Updated the relevant parts of the code to handle and utilize these new options for P2P communication.
- Modified the documentation to include details about the newly added P2P node options.

## Motivation and Context
In order to facilitate more flexible P2P networking , this PR introduces two essential options: `node_host_ip` for specifying the local IPv4 address and `node_host_port` for selecting any available port. These options provide users with greater control over the P2P configuration based on their specific requirements.

## Configuration Example
```yaml
p2p:
  enable: true
  service_discovery_id: "p2p_p2p_service"
  service_command_topic: "p2p_p2p_service_topic"
  service_discover_mode: "advertise" # advertise or announce
  node_host_ip: "127.0.0.1" # local IPv4 IP
  node_host_port: 0 # any available port
