### PR TITLE
feat(EXISTS)add concurrent to cmdEXISTS

### DIFF
--- a/strings_test.go
+++ b/strings_test.go
@@ -68,6 +68,12 @@ func TestKV(t *testing.T) {
 		t.Fatal(n)
 	}
 
+	if n, err := c.Exists(ctx, "a", "a", "a").Result(); err != nil {
+		t.Fatal(err)
+	} else if n != 3 {
+		t.Fatal(n)
+	}
+
 	if n, err := c.Exists(ctx, "a", "b", "c", "d").Result(); err != nil {
 		t.Fatal(err)
 	} else if n != 2 {


### PR DESCRIPTION
This commit enhancement to the `cmdEXISTS` function by implementing concurrent checks for key existence. This change leverages parallelism to reduce the overall execution time, especially when checking a large number of keys.

The `cmdEXISTS` function now processes keys in parallel, adhering to a configurable concurrency limit. This approach ensures that the function remains efficient even under high load, while maintaining control over the number of concurrent operations.

### Key Changes:
1. **Concurrent Key Checks**: Keys are now checked concurrently using goroutines, significantly improving performance for large sets of keys.
2. **Accurate Counting**: The function accurately counts the number of existing keys, including multiple mentions of the same key in the arguments.

### Syntax:
```plaintext
EXISTS key [key ...]
