### PR TITLE
feat(command): update MGET command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,3 +106,10 @@ build-linux-armv7 build-release-linux-armv7:
 	mkdir bin; \
 	fi
 	GOOS=linux GOARCH=arm GOARM=7 go build $(CFLAGS) -o ./bin/$(RELEASE_BIN_NAME)_linux_armv7 $(SRCS)
+
+# Build for local environment
+localbuild:
+	if [ ! -d "./bin/" ]; then \
+	mkdir bin; \
+	fi
+	go build $(CFLAGS) -o ./bin/$(RELEASE_BIN_NAME) $(SRCS)

--- a/strings.go
+++ b/strings.go
@@ -700,22 +700,34 @@ func cmdMSET(m uhaha.Machine, args []string) (interface{}, error) {
 }
 
 func cmdMGET(m uhaha.Machine, args []string) (interface{}, error) {
+	// Check the number of arguments; at least one key is required
 	if len(args) < 2 {
 		return nil, uhaha.ErrWrongNumArgs
 	}
 
+	// Extract all keys from the arguments
 	keys := make([][]byte, len(args)-1)
-
 	for i := 1; i < len(args); i++ {
 		keys[i-1] = []byte(args[i])
 	}
 
-	v, err := ldb.MGet(keys...)
+	// Retrieve the values for all specified keys
+	values, err := ldb.MGet(keys...)
 	if err != nil {
 		return nil, err
 	}
 
-	return v, nil
+	// Convert the result into a slice of interfaces for RESP compatibility
+	result := make([]interface{}, len(values))
+	for i, v := range values {
+		if v == nil {
+			result[i] = nil // If the value is nil, the key does not exist or is not a string
+		} else {
+			result[i] = v
+		}
+	}
+
+	return result, nil
 }
 
 func cmdTTL(m uhaha.Machine, args []string) (interface{}, error) {

--- a/strings_test.go
+++ b/strings_test.go
@@ -313,32 +313,41 @@ func TestKV(t *testing.T) {
 	}
 }
 
-func TestKVM(t *testing.T) {
+func TestMGET(t *testing.T) {
 	c := getTestConn()
 	ctx := context.Background()
 
+	// Set up initial key-value pairs
 	if ok, err := c.MSet(ctx, "a", "1", "b", "2").Result(); err != nil {
-		t.Error(err)
+		t.Fatalf("MSET failed: %v", err)
 	} else if ok != "OK" {
-		t.Error(ok)
+		t.Fatalf("MSET returned unexpected result: %v", ok)
 	}
 
-	if v, err := c.MGet(ctx, "a", "b", "c").Result(); err != nil {
-		t.Error(err)
-	} else if len(v) != 3 {
-		t.Error(len(v))
-	} else {
-		if vv, ok := v[0].(string); !ok || vv != "1" {
-			t.Error("not 1")
-		}
+	// Retrieve values using MGET
+	values, err := c.MGet(ctx, "a", "b", "c").Result()
+	if err != nil {
+		t.Fatalf("MGET failed: %v", err)
+	}
 
-		if vv, ok := v[1].(string); !ok || vv != "2" {
-			t.Error("not 2")
-		}
+	// Validate the number of returned values
+	if len(values) != 3 {
+		t.Fatalf("Expected 3 values, got %d", len(values))
+	}
 
-		if v[2] != "" {
-			t.Error("must nil")
-		}
+	// Validate the value for key "a"
+	if v, ok := values[0].(string); !ok || v != "1" {
+		t.Errorf("Expected value '1' for key 'a', got %v", values[0])
+	}
+
+	// Validate the value for key "b"
+	if v, ok := values[1].(string); !ok || v != "2" {
+		t.Errorf("Expected value '2' for key 'b', got %v", values[1])
+	}
+
+	// Validate the value for non-existent key "c"
+	if values[2] != nil {
+		t.Errorf("Expected nil for non-existent key 'c', got %v", values[2])
 	}
 }
 


### PR DESCRIPTION
- Added argument validation to ensure at least one key is provided.
- Extracted keys from the arguments and converted them to byte slices.
- Implemented retrieval of values for all specified keys using `ldb.MGet`.
- Converted the result into a slice of interfaces for RESP compatibility.
- Handled nil values to indicate non-existent or non-string keys.