### PR TITLE
refactor: return nil when error has already been checked

### DIFF
--- a/set.go
+++ b/set.go
@@ -55,7 +55,7 @@ func soptGeneric(args [][]byte, optType byte) ([][]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	return v, err
+	return v, nil
 }
 
 func soptStoreGeneric(args [][]byte, optType byte) (interface{}, error) {


### PR DESCRIPTION
Since err != nil has been judged before, nil is returned directly here, which is more obvious, readable and less error-prone.