### PR TITLE
refactor: use the built-in max/min to simplify the code

### DIFF
--- a/IceFireDB-PubSub/utils/reader.go
+++ b/IceFireDB-PubSub/utils/reader.go
@@ -32,13 +32,6 @@ type Reader struct {
 	WritePosition int
 }
 
-func max(a, b int) int {
-	if a > b {
-		return a
-	}
-	return b
-}
-
 func NewReader(reader io.Reader) *Reader {
 	return &Reader{reader: reader, Buffer: make([]byte, bufStepSize)}
 }

--- a/IceFireDB-Redis-Proxy/utils/reader.go
+++ b/IceFireDB-Redis-Proxy/utils/reader.go
@@ -32,13 +32,6 @@ type Reader struct {
 	WritePosition int
 }
 
-func max(a, b int) int {
-	if a > b {
-		return a
-	}
-	return b
-}
-
 func NewReader(reader io.Reader) *Reader {
 	return &Reader{reader: reader, Buffer: make([]byte, bufStepSize)}
 }


### PR DESCRIPTION
In Go 1.21, the standard library includes built-in [max/min](https://pkg.go.dev/builtin@go1.21.0#max) function, which can greatly simplify the code.
