### PR TITLE
refactor: use time.DateTime

### DIFF
--- a/IceFireDB-PubSub/utils/func.go
+++ b/IceFireDB-PubSub/utils/func.go
@@ -31,7 +31,7 @@ func GoWithRecover(handler func(), recoverHandler func(r interface{})) {
 	go func() {
 		defer func() {
 			if r := recover(); r != nil {
-				log.Printf("%s goroutine panic: %v\n%s\n\n", time.Now().Format("2006-01-02 15:04:05"), r, string(debug.Stack()))
+				log.Printf("%s goroutine panic: %v\n%s\n\n", time.Now().Format(time.DateTime), r, string(debug.Stack()))
 				if recoverHandler != nil {
 					go func() {
 						defer func() {

--- a/IceFireDB-Redis-Proxy/utils/func.go
+++ b/IceFireDB-Redis-Proxy/utils/func.go
@@ -32,7 +32,7 @@ func GoWithRecover(handler func(), recoverHandler func(r interface{})) {
 		defer func() {
 			if r := recover(); r != nil {
 
-				log.Println("%s goroutine panic: %v\n%s\n", time.Now().Format("2006-01-02 15:04:05"), r, string(debug.Stack()))
+				log.Println("%s goroutine panic: %v\n%s\n", time.Now().Format(time.DateTime), r, string(debug.Stack()))
 				if recoverHandler != nil {
 					go func() {
 						defer func() {

--- a/IceFireDB-SQLProxy/utils/util.go
+++ b/IceFireDB-SQLProxy/utils/util.go
@@ -27,7 +27,7 @@ func GoWithRecover(handler func(), recoverHandler func(r interface{})) {
 	go func() {
 		defer func() {
 			if r := recover(); r != nil {
-				logrus.Errorf("%s goroutine panic: %v\n%s\n", time.Now().Format("2006-01-02 15:04:05"), r, string(debug.Stack()))
+				logrus.Errorf("%s goroutine panic: %v\n%s\n", time.Now().Format(time.DateTime), r, string(debug.Stack()))
 				if recoverHandler != nil {
 					go func() {
 						defer func() {

--- a/IceFireDB-SQLite/utils/util.go
+++ b/IceFireDB-SQLite/utils/util.go
@@ -27,7 +27,7 @@ func GoWithRecover(handler func(), recoverHandler func(r interface{})) {
 	go func() {
 		defer func() {
 			if r := recover(); r != nil {
-				logrus.Errorf("%s goroutine panic: %v\n%s\n", time.Now().Format("2006-01-02 15:04:05"), r, string(debug.Stack()))
+				logrus.Errorf("%s goroutine panic: %v\n%s\n", time.Now().Format(time.DateTime), r, string(debug.Stack()))
 				if recoverHandler != nil {
 					go func() {
 						defer func() {


### PR DESCRIPTION
The new [time.DateTime constant](https://pkg.go.dev/time@go1.20) added in Go 1.20 can improve code readability.