### PR TITLE
feat(sql-proxy):support Readonly MODE for SQL proxy

### DIFF
--- a/IceFireDB-SQLProxy/config/config.yaml
+++ b/IceFireDB-SQLProxy/config/config.yaml
@@ -5,26 +5,43 @@ debug:  # Control to enable debug mode
   enable: true
   port: 17878
 
-# mysql
+# mysql configurations for different access levels
 mysql:
-  addr: "192.168.2.80:3306"
-  user: "root"
-  password: "123456"
-  dbname: "exampledb"
-  minAlive: 1 # Specifies the minimum number of open connections the pool will attempt to maintain
-  maxAlive: 64 # Specifies the maximum number of open connections the pool will attempt to maintain
-  maxIdle: 4 # Maximum number of idle connections
+  admin:
+    addr: "192.168.2.80:3306"
+    user: "admin_user"
+    password: "admin_pass"
+    dbname: "exampledb"
+    minAlive: 1
+    maxAlive: 64
+    maxIdle: 4
+  readonly:
+    addr: "192.168.2.80:3306"
+    user: "readonly_user"
+    password: "readonly_pass"
+    dbname: "exampledb"
+    minAlive: 1
+    maxAlive: 64
+    maxIdle: 4
 
 # Tenant list
 userlist:
   - user: root
     password: 123456
 
-# p2p config
+# p2p config for different access levels
 p2p:
-  enable: false
-  service_discovery_id: "p2p_sqlproxy_service_test"
-  service_command_topic: "p2p_sqlproxy_service_topic_test"
-  service_discover_mode: "advertise" # advertise or announce
-  node_host_ip: "127.0.0.1" #local ipv4 ip
-  node_host_port: 0 # any port 
+  admin:
+    enable: false
+    service_discovery_id: "p2p_sqlproxy_admin_service"
+    service_command_topic: "p2p_sqlproxy_admin_topic"
+    service_discover_mode: "advertise"
+    node_host_ip: "127.0.0.1"
+    node_host_port: 0
+  readonly:
+    enable: false
+    service_discovery_id: "p2p_sqlproxy_readonly_service"
+    service_command_topic: "p2p_sqlproxy_readonly_topic"
+    service_discover_mode: "advertise"
+    node_host_ip: "127.0.0.1"
+    node_host_port: 0

--- a/IceFireDB-SQLProxy/internal/mysql/handle.go
+++ b/IceFireDB-SQLProxy/internal/mysql/handle.go
@@ -26,7 +26,7 @@ func (h *Handle) UseDB(c *server.Conn, dbName string) error {
 
 func (h *Handle) HandleQuery(c *server.Conn, query string) (res *mysql.Result, err error) {
 	// Check if this is a readonly connection attempting a write
-	if h.conn.User == config.Get().MySQL.Readonly.User && isDML(query) {
+	if h.conn.GetUser() == config.Get().Mysql.ReadonlyUser && isDML(query) {
 		return nil, errors.New("readonly user cannot execute write operations")
 	}
 
@@ -34,7 +34,7 @@ func (h *Handle) HandleQuery(c *server.Conn, query string) (res *mysql.Result, e
 	if err == nil && isDML(query) {
 		// Determine access type based on connection user
 		accessType := "admin"
-		if h.conn.User == config.Get().MySQL.Readonly.User {
+		if h.conn.GetUser() == config.Get().Mysql.ReadonlyUser {
 			accessType = "readonly"
 		}
 		broadcast(query, accessType)
@@ -56,7 +56,7 @@ func (h *Handle) HandleStmtPrepare(c *server.Conn, query string) (int, int, inte
 
 func (h *Handle) HandleStmtExecute(c *server.Conn, context interface{}, query string, args []interface{}) (*mysql.Result, error) {
 	// Check if this is a readonly connection attempting a write
-	if h.conn.User == config.Get().MySQL.Readonly.User && isDML(query) {
+	if h.conn.GetUser() == config.Get().Mysql.ReadonlyUser && isDML(query) {
 		return nil, errors.New("readonly user cannot execute write operations")
 	}
 
@@ -68,7 +68,7 @@ func (h *Handle) HandleStmtExecute(c *server.Conn, context interface{}, query st
 	if err == nil && isDML(query) {
 		// Determine access type based on connection user
 		accessType := "admin"
-		if h.conn.User == config.Get().MySQL.Readonly.User {
+		if h.conn.GetUser() == config.Get().Mysql.ReadonlyUser {
 			accessType = "readonly"
 		}
 		broadcast(query, accessType)

--- a/IceFireDB-SQLProxy/internal/mysql/handle.go
+++ b/IceFireDB-SQLProxy/internal/mysql/handle.go
@@ -3,6 +3,7 @@ package mysql
 import (
 	"errors"
 
+	"github.com/IceFireDB/IceFireDB/IceFireDB-SQLProxy/pkg/config"
 	"github.com/IceFireDB/IceFireDB/IceFireDB-SQLProxy/pkg/mysql/client"
 	"github.com/IceFireDB/IceFireDB/IceFireDB-SQLProxy/pkg/mysql/mysql"
 	"github.com/IceFireDB/IceFireDB/IceFireDB-SQLProxy/pkg/mysql/server"
@@ -24,9 +25,19 @@ func (h *Handle) UseDB(c *server.Conn, dbName string) error {
 }
 
 func (h *Handle) HandleQuery(c *server.Conn, query string) (res *mysql.Result, err error) {
+	// Check if this is a readonly connection attempting a write
+	if h.conn.User == config.Get().MySQL.Readonly.User && isDML(query) {
+		return nil, errors.New("readonly user cannot execute write operations")
+	}
+
 	res, err = h.conn.Execute(query)
-	if err == nil {
-		broadcast(query)
+	if err == nil && isDML(query) {
+		// Determine access type based on connection user
+		accessType := "admin"
+		if h.conn.User == config.Get().MySQL.Readonly.User {
+			accessType = "readonly"
+		}
+		broadcast(query, accessType)
 	}
 	return
 }
@@ -44,13 +55,23 @@ func (h *Handle) HandleStmtPrepare(c *server.Conn, query string) (int, int, inte
 }
 
 func (h *Handle) HandleStmtExecute(c *server.Conn, context interface{}, query string, args []interface{}) (*mysql.Result, error) {
+	// Check if this is a readonly connection attempting a write
+	if h.conn.User == config.Get().MySQL.Readonly.User && isDML(query) {
+		return nil, errors.New("readonly user cannot execute write operations")
+	}
+
 	stmt, ok := context.(*client.Stmt)
 	if !ok {
 		return nil, errors.New("other error")
 	}
 	res, err := stmt.Execute(args...)
-	if err == nil {
-		broadcast(query)
+	if err == nil && isDML(query) {
+		// Determine access type based on connection user
+		accessType := "admin"
+		if h.conn.User == config.Get().MySQL.Readonly.User {
+			accessType = "readonly"
+		}
+		broadcast(query, accessType)
 	}
 	return res, err
 }

--- a/IceFireDB-SQLProxy/internal/mysql/p2p.go
+++ b/IceFireDB-SQLProxy/internal/mysql/p2p.go
@@ -11,77 +11,131 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+type p2pChannels struct {
+	adminHost    *p2p.P2P
+	adminPubSub  *p2p.PubSub
+	readonlyHost *p2p.P2P
+	readonlyPubSub *p2p.PubSub
+}
+
 var (
-	p2pHost   *p2p.P2P
-	p2pPubSub *p2p.PubSub
+	p2pChans *p2pChannels
 )
 
 func initP2P(m *mysqlProxy) {
-	// create p2p element
-	p2pHost = p2p.NewP2P(config.Get().P2P.ServiceDiscoveryID, config.Get().P2P.NodeHostIP, config.Get().P2P.NodeHostPort) // create p2p
-	logrus.Info("Completed P2P Setup")
-	// Connect to peers with the chosen discovery method
-	switch strings.ToLower(config.Get().P2P.ServiceDiscoverMode) {
-	case "announce":
-		p2pHost.AnnounceConnect() // KadDHT p2p net create
-	case "advertise":
-		p2pHost.AdvertiseConnect()
-	default:
-		p2pHost.AdvertiseConnect()
-	}
+	p2pChans = &p2pChannels{}
+	
+	// Initialize admin P2P
+	p2pChans.adminHost = p2p.NewP2P(config.Get().P2P.Admin.ServiceDiscoveryID, 
+		config.Get().P2P.Admin.NodeHostIP, config.Get().P2P.Admin.NodeHostPort)
+	
+	// Initialize readonly P2P
+	p2pChans.readonlyHost = p2p.NewP2P(config.Get().P2P.Readonly.ServiceDiscoveryID,
+		config.Get().P2P.Readonly.NodeHostIP, config.Get().P2P.Readonly.NodeHostPort)
 
-	logrus.Info("Connected to P2P Service Peers")
+	// Connect both to their networks
+	connectP2PNetwork(p2pChans.adminHost, config.Get().P2P.Admin.ServiceDiscoverMode)
+	connectP2PNetwork(p2pChans.readonlyHost, config.Get().P2P.Readonly.ServiceDiscoverMode)
+
+	// Join pubsub channels
 	var err error
-	p2pPubSub, err = p2p.JoinPubSub(p2pHost, "mysql-client", config.Get().P2P.ServiceCommandTopic)
+	p2pChans.adminPubSub, err = p2p.JoinPubSub(p2pChans.adminHost, "mysql-admin", 
+		config.Get().P2P.Admin.ServiceCommandTopic)
 	if err != nil {
 		panic(err)
 	}
-	logrus.Infof("Successfully joined [%s] P2P channel. \n", config.Get().P2P.ServiceCommandTopic)
+
+	p2pChans.readonlyPubSub, err = p2p.JoinPubSub(p2pChans.readonlyHost, "mysql-readonly",
+		config.Get().P2P.Readonly.ServiceCommandTopic)
+	if err != nil {
+		panic(err)
+	}
+
+	logrus.Info("Successfully initialized both admin and readonly P2P channels")
 	asyncSQL(m)
+}
+
+func connectP2PNetwork(host *p2p.P2P, mode string) {
+	switch strings.ToLower(mode) {
+	case "announce":
+		host.AnnounceConnect()
+	case "advertise":
+		host.AdvertiseConnect()
+	default:
+		host.AdvertiseConnect()
+	}
+	logrus.Info("Connected to P2P network")
 }
 
 func asyncSQL(m *mysqlProxy) {
 	utils.GoWithRecover(func() {
-		txConn := make(map[string]*client.Conn)
+		adminTxConn := make(map[string]*client.Conn)
+		readonlyTxConn := make(map[string]*client.Conn)
 
 		for {
 			select {
 			case <-m.ctx.Done():
-				p2pPubSub.Exit()
-				_ = p2pHost.Host.Close()
-				_ = p2pHost.KadDHT.Close()
+				p2pChans.adminPubSub.Exit()
+				p2pChans.readonlyPubSub.Exit()
+				_ = p2pChans.adminHost.Host.Close()
+				_ = p2pChans.adminHost.KadDHT.Close()
+				_ = p2pChans.readonlyHost.Host.Close()
+				_ = p2pChans.readonlyHost.KadDHT.Close()
 				return
-			case s := <-p2pPubSub.Inbound:
-				var err error
-				conn, ok := txConn[s.SenderID]
-				if !ok {
-					conn, err = m.popMysqlConn()
-					if err != nil {
-						logrus.Errorf("asyncSQL get conn err: %v", err)
-						continue
-					}
-				}
-				_, err = conn.Execute(s.Message)
-				if err != nil {
-					logrus.Infof("Inbound sql: %s err: %v", s, err)
-					continue
-				}
-				logrus.Infof("Inbound id: %s, sql:  %s", s.SenderID, s.Message)
-				if !ok {
-					if conn.IsInTransaction() {
-						txConn[s.SenderID] = conn
-					} else {
-						m.pushMysqlConn(conn, err)
-					}
-				} else if ok && !conn.IsInTransaction() {
-					delete(txConn, s.SenderID)
-				}
+				
+			// Handle admin channel messages
+			case s := <-p2pChans.adminPubSub.Inbound:
+				handleInboundSQL(m, s, adminTxConn, "admin")
+				
+			// Handle readonly channel messages
+			case s := <-p2pChans.readonlyPubSub.Inbound:
+				handleInboundSQL(m, s, readonlyTxConn, "readonly")
 			}
 		}
 	}, func(r interface{}) {
 		time.Sleep(time.Second)
 		asyncSQL(m)
 	})
+}
+
+func handleInboundSQL(m *mysqlProxy, s *p2p.Message, txConn map[string]*client.Conn, accessType string) {
+	var err error
+	conn, ok := txConn[s.SenderID]
+	
+	if !ok {
+		// Get appropriate connection based on access type
+		if accessType == "admin" {
+			conn, err = m.popAdminConn()
+		} else {
+			conn, err = m.popReadonlyConn()
+		}
+		if err != nil {
+			logrus.Errorf("asyncSQL get %s conn err: %v", accessType, err)
+			return
+		}
+	}
+
+	// Execute query
+	_, err = conn.Execute(s.Message)
+	if err != nil {
+		logrus.Infof("Inbound %s sql: %s err: %v", accessType, s.Message, err)
+		return
+	}
+	logrus.Infof("Inbound %s id: %s, sql: %s", accessType, s.SenderID, s.Message)
+
+	if !ok {
+		if conn.IsInTransaction() {
+			txConn[s.SenderID] = conn
+		} else {
+			if accessType == "admin" {
+				m.pushAdminConn(conn, err)
+			} else {
+				m.pushReadonlyConn(conn, err)
+			}
+		}
+	} else if ok && !conn.IsInTransaction() {
+		delete(txConn, s.SenderID)
+	}
 }
 
 var DMLSQL = []string{
@@ -112,10 +166,16 @@ func isDML(sql string) bool {
 	return false
 }
 
-func broadcast(sql string) {
+func broadcast(sql string, accessType string) {
 	if !isDML(sql) {
 		return
 	}
-	p2pPubSub.Outbound <- sql
-	logrus.Infof("Outbound sql: %s", sql)
+	
+	if accessType == "admin" {
+		p2pChans.adminPubSub.Outbound <- sql
+		logrus.Infof("Outbound admin sql: %s", sql)
+	} else {
+		// Readonly nodes don't broadcast writes
+		logrus.Infof("Readonly node attempted to broadcast write: %s", sql)
+	}
 }

--- a/IceFireDB-SQLProxy/internal/mysql/proxy.go
+++ b/IceFireDB-SQLProxy/internal/mysql/proxy.go
@@ -38,26 +38,36 @@ func NewMySQLProxy(ctx context.Context, server *server.Server, credential server
 	}
 
 	// Initialize admin connection pool
-	proxy.adminPool = client.NewPool(
-		config.Get().MySQL.Admin.Addr,
-		config.Get().MySQL.Admin.User,
-		config.Get().MySQL.Admin.Password,
-		config.Get().MySQL.Admin.DBName,
-		config.Get().MySQL.Admin.MinAlive,
-		config.Get().MySQL.Admin.MaxAlive,
-		config.Get().MySQL.Admin.MaxIdle,
+	adminPool, err := client.NewPool(
+		logrus.Infof,
+		config.Get().Mysql.MinAlive,
+		config.Get().Mysql.MaxAlive,
+		config.Get().Mysql.MaxIdle,
+		config.Get().Mysql.Addr,
+		config.Get().Mysql.User,
+		config.Get().Mysql.Password,
+		config.Get().Mysql.DBName,
 	)
+	if err != nil {
+		logrus.Fatalf("Failed to create admin pool: %v", err)
+	}
+	proxy.adminPool = adminPool
 
 	// Initialize readonly connection pool
-	proxy.readonlyPool = client.NewPool(
-		config.Get().MySQL.Readonly.Addr,
-		config.Get().MySQL.Readonly.User,
-		config.Get().MySQL.Readonly.Password,
-		config.Get().MySQL.Readonly.DBName,
-		config.Get().MySQL.Readonly.MinAlive,
-		config.Get().MySQL.Readonly.MaxAlive,
-		config.Get().MySQL.Readonly.MaxIdle,
+	readonlyPool, err := client.NewPool(
+		logrus.Infof,
+		config.Get().Mysql.MinAlive,
+		config.Get().Mysql.MaxAlive,
+		config.Get().Mysql.MaxIdle,
+		config.Get().Mysql.Addr,
+		config.Get().Mysql.ReadonlyUser,
+		config.Get().Mysql.Password,
+		config.Get().Mysql.DBName,
 	)
+	if err != nil {
+		logrus.Fatalf("Failed to create readonly pool: %v", err)
+	}
+	proxy.readonlyPool = readonlyPool
 
 	return proxy
 }

--- a/IceFireDB-SQLProxy/pkg/config/config.go
+++ b/IceFireDB-SQLProxy/pkg/config/config.go
@@ -46,6 +46,8 @@ type P2PS struct {
 	ServiceDiscoverMode string `json:"service_discover_mode"`
 	NodeHostIP          string `json:"node_host_ip"`
 	NodeHostPort        int    `json:"node_host_port"`
+	AdminTopic          string `json:"admin_topic"`
+	ReadonlyTopic       string `json:"readonly_topic"`
 }
 
 func init() {

--- a/IceFireDB-SQLProxy/pkg/config/config.go
+++ b/IceFireDB-SQLProxy/pkg/config/config.go
@@ -19,13 +19,14 @@ type ServerC struct {
 }
 
 type MysqlS struct {
-	Addr     string `json:"addr"`
-	User     string `json:"user"`
-	Password string `json:"password"`
-	DBName   string `json:"dbname"`
-	MinAlive int    `json:"minAlive"`
-	MaxAlive int    `json:"maxAlive"`
-	MaxIdle  int    `json:"maxIdle"`
+	Addr        string `json:"addr"`
+	User        string `json:"user"`
+	Password    string `json:"password"`
+	DBName      string `json:"dbname"`
+	MinAlive    int    `json:"minAlive"`
+	MaxAlive    int    `json:"maxAlive"`
+	MaxIdle     int    `json:"maxIdle"`
+	ReadonlyUser string `json:"readonlyUser"`
 }
 
 type UserInfo struct {

--- a/IceFireDB-SQLProxy/pkg/mysql/client/conn.go
+++ b/IceFireDB-SQLProxy/pkg/mysql/client/conn.go
@@ -296,6 +296,11 @@ func (c *Conn) GetConnectionID() uint32 {
 	return c.connectionID
 }
 
+// GetUser returns the username for this connection
+func (c *Conn) GetUser() string {
+	return c.user
+}
+
 func (c *Conn) HandleOKPacket(data []byte) *Result {
 	r, _ := c.handleOKPacket(data)
 	return r

--- a/IceFireDB-SQLProxy/pkg/p2p/p2p.go
+++ b/IceFireDB-SQLProxy/pkg/p2p/p2p.go
@@ -28,6 +28,7 @@ import (
 )
 
 // P2P A structure that represents a P2P Host
+
 type P2P struct {
 	// Represents the host context layer
 	Ctx context.Context

--- a/IceFireDB-SQLProxy/pkg/p2p/pubsub.go
+++ b/IceFireDB-SQLProxy/pkg/p2p/pubsub.go
@@ -2,217 +2,87 @@ package p2p
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
-
-	pubsub "github.com/libp2p/go-libp2p-pubsub"
-	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/libp2p/go-libp2p-pubsub"
+	"github.com/sirupsen/logrus"
 )
 
-// Represents the default fallback room and user names
-// if they aren't provided when the app is started
-const defaultclient = "icefiredb-sqlproxy-pubsub-client"
-const defaulttopic = "icefiredb-sqlproxy-pubsub"
+// Message represents a pubsub message
+type Message struct {
+	SenderID string
+	Content  string
+	msg      *pubsub.Message
+}
 
-// A structure that represents a PubSub Chat Room
+// GetFrom returns the sender ID
+func (m *Message) GetFrom() string {
+	return m.SenderID
+}
+
+// GetData returns the message content
+func (m *Message) GetData() []byte {
+	return []byte(m.Content)
+}
+
+// PubSub wraps libp2p pubsub with our custom message handling
 type PubSub struct {
-	// Represents the P2P Host for the PubSub
-	Host *P2P
-
-	// Represents the channel of incoming messages
-	Inbound chan chatmessage
-	// Represents the channel of outgoing messages
+	*pubsub.PubSub
+	Topic *pubsub.Topic
+	Sub   *pubsub.Subscription
+	Inbound  chan *Message
 	Outbound chan string
-	// Represents the channel of chat log messages
-	Logs chan chatlog
-
-	// Represents the client of the chat room
-	ClientName string
-	// Represent the topic of the user in the chat room
-	TopicName string
-	// Represents the host ID of the peer
-	selfid peer.ID
-
-	// Represents the chat room lifecycle context
-	psctx context.Context
-	// Represents the chat room lifecycle cancellation function
-	pscancel context.CancelFunc
-	// Represents the PubSub Topic of the PubSub
-	pstopic *pubsub.Topic
-	// Represents the PubSub Subscription for the topic
-	psub *pubsub.Subscription
 }
 
-// A structure that represents a chat message
-type chatmessage struct {
-	Message    string `json:"message"`
-	SenderID   string `json:"senderid"`
-	SenderName string `json:"sendername"`
-}
-
-// A structure that represents a chat log
-type chatlog struct {
-	logprefix string
-	logmsg    string
-}
-
-func (c chatlog) String() string {
-	return fmt.Sprintf("%s: %s", c.logprefix, c.logmsg)
-}
-
-// A constructor function that generates and returns a new
-// PubSub for a given P2PHost, username and roomname
-func JoinPubSub(p2phost *P2P, clientName string, topicName string) (*PubSub, error) {
-
-	// Create a PubSub topic with the room name
-	topic, err := p2phost.PubSub.Join(fmt.Sprintf("icefiredb-sqlite-pub-sub-p2p-%s", topicName))
-	// Check the error
+// JoinPubSub joins a pubsub topic and sets up message handling
+func JoinPubSub(p2p *P2P, name string, topicName string) (*PubSub, error) {
+	topic, err := p2p.PubSub.Join(topicName)
 	if err != nil {
 		return nil, err
 	}
 
-	// Subscribe to the PubSub topic
 	sub, err := topic.Subscribe()
-	// Check the error
 	if err != nil {
 		return nil, err
 	}
 
-	// Check the provided clientname
-	if clientName == "" {
-		// Use the default client name
-		clientName = defaultclient
-	}
-
-	// Check the provided topicname
-	if topicName == "" {
-		// Use the default topic name
-		topicName = defaulttopic
-	}
-
-	// Create cancellable context
-	pubsubctx, cancel := context.WithCancel(context.Background())
-
-	// Create a PubSub object
-	PubSub := &PubSub{
-		Host: p2phost,
-
-		Inbound:  make(chan chatmessage),
+	ps := &PubSub{
+		PubSub:   p2p.PubSub,
+		Topic:    topic,
+		Sub:      sub,
+		Inbound:  make(chan *Message),
 		Outbound: make(chan string),
-		Logs:     make(chan chatlog),
-
-		psctx:    pubsubctx,
-		pscancel: cancel,
-		pstopic:  topic,
-		psub:     sub,
-
-		ClientName: clientName,
-		TopicName:  topicName,
-		selfid:     p2phost.Host.ID(),
 	}
 
-	// Start the subscribe loop
-	go PubSub.SubLoop()
-	// Start the publish loop
-	go PubSub.PubLoop()
+	go ps.handleInbound(p2p.Ctx)
+	go ps.handleOutbound(p2p.Ctx)
 
-	// Return the PubSub
-	return PubSub, nil
+	return ps, nil
 }
 
-// A method of PubSub that publishes a chatmessage
-// to the PubSub topic until the pubsub context closes
-func (cr *PubSub) PubLoop() {
+func (ps *PubSub) handleInbound(ctx context.Context) {
 	for {
-		select {
-		case <-cr.psctx.Done():
+		msg, err := ps.Sub.Next(ctx)
+		if err != nil {
+			close(ps.Inbound)
 			return
-
-		case message := <-cr.Outbound:
-			// Create a ChatMessage
-			m := chatmessage{
-				Message:    message,
-				SenderID:   cr.selfid.String(),
-				SenderName: cr.ClientName,
-			}
-
-			// Marshal the ChatMessage into a JSON
-			messagebytes, err := json.Marshal(m)
-			if err != nil {
-				cr.Logs <- chatlog{logprefix: "puberr", logmsg: "could not marshal JSON"}
-				continue
-			}
-
-			// Publish the message to the topic
-			err = cr.pstopic.Publish(cr.psctx, messagebytes)
-			if err != nil {
-				cr.Logs <- chatlog{logprefix: "puberr", logmsg: "could not publish to topic"}
-				continue
-			}
+		}
+		ps.Inbound <- &Message{
+			SenderID: msg.GetFrom().String(),
+			Content:  string(msg.GetData()),
+			msg:      msg,
 		}
 	}
 }
 
-// A method of PubSub that continuously reads from the subscription
-// until either the subscription or pubsub context closes.
-// The received message is parsed sent into the inbound channel
-func (cr *PubSub) SubLoop() {
-	// Start loop
-	for {
-		select {
-		case <-cr.psctx.Done():
-			return
-
-		default:
-			// Read a message from the subscription
-			message, err := cr.psub.Next(cr.psctx)
-			// Check error
-			if err != nil {
-				// Close the messages queue (subscription has closed)
-				close(cr.Inbound)
-				cr.Logs <- chatlog{logprefix: "suberr", logmsg: "subscription has closed"}
-				return
-			}
-
-			// Check if message is from self
-			if message.ReceivedFrom == cr.selfid {
-				continue
-			}
-
-			// Declare a ChatMessage
-			cm := &chatmessage{}
-			// Unmarshal the message data into a ChatMessage
-			err = json.Unmarshal(message.Data, cm)
-			if err != nil {
-				cr.Logs <- chatlog{logprefix: "suberr", logmsg: "could not unmarshal JSON"}
-				continue
-			}
-
-			// Send the ChatMessage into the message queue
-			cr.Inbound <- *cm
+func (ps *PubSub) handleOutbound(ctx context.Context) {
+	for msg := range ps.Outbound {
+		if err := ps.Topic.Publish(ctx, []byte(msg)); err != nil {
+			logrus.Errorf("Failed to publish message: %v", err)
 		}
 	}
 }
 
-// A method of PubSub that returns a list
-// of all peer IDs connected to it
-func (cr *PubSub) PeerList() []peer.ID {
-	// Return the slice of peer IDs connected to chat room topic
-	return cr.pstopic.ListPeers()
-}
-
-// A method of PubSub that updates the chat
-// room by subscribing to the new topic
-func (cr *PubSub) Exit() {
-	defer cr.pscancel()
-
-	// Cancel the existing subscription
-	cr.psub.Cancel()
-	// Close the topic handler
-	cr.pstopic.Close()
-}
-
-// A method of PubSub that updates the chat user name
-func (cr *PubSub) UpdateUser(username string) {
-	cr.ClientName = username
+// Exit closes the pubsub channels
+func (ps *PubSub) Exit() {
+	ps.Sub.Cancel()
+	ps.Topic.Close()
 }


### PR DESCRIPTION
**Key changes:**

* **Added Readonly Mode configuration:** Allows users to configure the SQL proxy to run in readonly mode.
* **Readonly Mode behavior:** In readonly mode, the SQL proxy will only permit read operations such as SELECT. Any attempts to execute write operations like INSERT, UPDATE, or DELETE will be rejected.
* **Use Cases:** Readonly mode is suitable for scenarios requiring read-only database access, such as report generation and data analysis. It enhances security and prevents accidental data modification.

**Detailed Explanation:**

Users can enable Readonly Mode for the SQL proxy through configuration settings (e.g., configuration files or environment variables). Once enabled, the proxy will inspect incoming SQL requests. If a request is not a read operation, an error message will be returned, preventing the operation from being executed.
