### PR TITLE
refactor: use the built-in max/min to simplify the code

### DIFF
--- a/IceFireDB-PubSub/test/redis.go
+++ b/IceFireDB-PubSub/test/redis.go
@@ -74,10 +74,7 @@ var (
 // sliceBinOp applies an operator to all slice elements, with Redis string
 // padding logic.
 func sliceBinOp(f func(a, b byte) byte, a, b []byte) []byte {
-	maxl := len(a)
-	if len(b) > maxl {
-		maxl = len(b)
-	}
+	maxl := max(len(b), len(a))
 	lA := make([]byte, maxl)
 	copy(lA, a)
 	lB := make([]byte, maxl)

--- a/IceFireDB-Redis-Proxy/test/redis.go
+++ b/IceFireDB-Redis-Proxy/test/redis.go
@@ -74,10 +74,7 @@ var (
 // sliceBinOp applies an operator to all slice elements, with Redis string
 // padding logic.
 func sliceBinOp(f func(a, b byte) byte, a, b []byte) []byte {
-	maxl := len(a)
-	if len(b) > maxl {
-		maxl = len(b)
-	}
+	maxl := max(len(b), len(a))
 	lA := make([]byte, maxl)
 	copy(lA, a)
 	lB := make([]byte, maxl)

--- a/IceFireDB-SQLProxy/pkg/mysql/client/pool.go
+++ b/IceFireDB-SQLProxy/pkg/mysql/client/pool.go
@@ -75,10 +75,11 @@ var (
 )
 
 // NewPool initializes new connection pool and uses params: addr, user, password, dbName and options.
-//     minAlive specifies the minimum number of open connections that the pool will try to maintain.
-//     maxAlive specifies the maximum number of open connections
-//       (for internal reasons, may be greater by 1 inside newConnectionProducer).
-//     maxIdle specifies the maximum number of idle connections (see DefaultIdleTimeout).
+//
+//	minAlive specifies the minimum number of open connections that the pool will try to maintain.
+//	maxAlive specifies the maximum number of open connections
+//	  (for internal reasons, may be greater by 1 inside newConnectionProducer).
+//	maxIdle specifies the maximum number of idle connections (see DefaultIdleTimeout).
 func NewPool(
 	logFunc LogFunc,
 	minAlive int,
@@ -419,11 +420,8 @@ func (pool *Pool) closeIdleConnectionsIfCan() {
 		return
 	}
 
-	closeFromIdx := idleCnt - canCloseCnt
-	if closeFromIdx < 0 {
-		// If there are enough requests in the "flight" now, then we can close all unnecessary
-		closeFromIdx = 0
-	}
+	// If there are enough requests in the "flight" now, then we can close all unnecessary
+	closeFromIdx := max(idleCnt-canCloseCnt, 0)
 
 	toClose := append([]Connection{}, pool.synchro.idleConnections[closeFromIdx:]...)
 

--- a/IceFireDB-SQLProxy/pkg/mysql/mysql/mysql_gtid.go
+++ b/IceFireDB-SQLProxy/pkg/mysql/mysql/mysql_gtid.go
@@ -99,10 +99,7 @@ func (s IntervalSlice) Normalize() IntervalSlice {
 			n = append(n, s[i])
 			continue
 		} else {
-			stop := s[i].Stop
-			if last.Stop > stop {
-				stop = last.Stop
-			}
+			stop := max(last.Stop, s[i].Stop)
 			n[len(n)-1] = Interval{last.Start, stop}
 		}
 	}

--- a/IceFireDB-SQLite/pkg/mysql/client/pool.go
+++ b/IceFireDB-SQLite/pkg/mysql/client/pool.go
@@ -75,10 +75,11 @@ var (
 )
 
 // NewPool initializes new connection pool and uses params: addr, user, password, dbName and options.
-//     minAlive specifies the minimum number of open connections that the pool will try to maintain.
-//     maxAlive specifies the maximum number of open connections
-//       (for internal reasons, may be greater by 1 inside newConnectionProducer).
-//     maxIdle specifies the maximum number of idle connections (see DefaultIdleTimeout).
+//
+//	minAlive specifies the minimum number of open connections that the pool will try to maintain.
+//	maxAlive specifies the maximum number of open connections
+//	  (for internal reasons, may be greater by 1 inside newConnectionProducer).
+//	maxIdle specifies the maximum number of idle connections (see DefaultIdleTimeout).
 func NewPool(
 	logFunc LogFunc,
 	minAlive int,
@@ -417,11 +418,8 @@ func (pool *Pool) closeIdleConnectionsIfCan() {
 		return
 	}
 
-	closeFromIdx := idleCnt - canCloseCnt
-	if closeFromIdx < 0 {
-		// If there are enough requests in the "flight" now, then we can close all unnecessary
-		closeFromIdx = 0
-	}
+	// If there are enough requests in the "flight" now, then we can close all unnecessary
+	closeFromIdx := max(idleCnt-canCloseCnt, 0)
 
 	toClose := append([]Connection{}, pool.synchro.idleConnections[closeFromIdx:]...)
 

--- a/IceFireDB-SQLite/pkg/mysql/mysql/mysql_gtid.go
+++ b/IceFireDB-SQLite/pkg/mysql/mysql/mysql_gtid.go
@@ -99,10 +99,7 @@ func (s IntervalSlice) Normalize() IntervalSlice {
 			n = append(n, s[i])
 			continue
 		} else {
-			stop := s[i].Stop
-			if last.Stop > stop {
-				stop = last.Stop
-			}
+			stop := max(last.Stop, s[i].Stop)
 			n[len(n)-1] = Interval{last.Start, stop}
 		}
 	}


### PR DESCRIPTION
In Go 1.21, the standard library includes built-in [max/min](https://pkg.go.dev/builtin@go1.21.0#max) function, which can greatly simplify the code.