### PR TITLE
refactor: use slices.Contains to simplify code

### DIFF
--- a/IceFireDB-PubSub/utils/func.go
+++ b/IceFireDB-PubSub/utils/func.go
@@ -23,6 +23,7 @@ import (
 	"log"
 	"os"
 	"runtime/debug"
+	"slices"
 	"strconv"
 	"time"
 )
@@ -63,12 +64,7 @@ func GetInterfaceString(param interface{}) string {
 }
 
 func InArray(in string, array []string) bool {
-	for k := range array {
-		if in == array[k] {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(array, in)
 }
 
 var _hostname string

--- a/IceFireDB-Redis-Proxy/utils/func.go
+++ b/IceFireDB-Redis-Proxy/utils/func.go
@@ -23,6 +23,7 @@ import (
 	"log"
 	"os"
 	"runtime/debug"
+	"slices"
 	"strconv"
 	"time"
 )
@@ -64,12 +65,7 @@ func GetInterfaceString(param interface{}) string {
 }
 
 func InArray(in string, array []string) bool {
-	for k := range array {
-		if in == array[k] {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(array, in)
 }
 
 var _hostname string

--- a/IceFireDB-SQLProxy/pkg/mysql/mysql/mariadb_gtid_test.go
+++ b/IceFireDB-SQLProxy/pkg/mysql/mysql/mariadb_gtid_test.go
@@ -2,6 +2,7 @@ package mysql
 
 import (
 	"github.com/pingcap/check"
+	"slices"
 )
 
 type mariaDBTestSuite struct{}
@@ -128,11 +129,8 @@ func (t *mariaDBTestSuite) TestParseMariaDBGTIDSet(c *check.C) {
 			// check String() function
 			inExpectedResult := false
 			actualStr := mariadbGTIDSet.String()
-			for _, str := range cs.expectedStr {
-				if str == actualStr {
-					inExpectedResult = true
-					break
-				}
+			if slices.Contains(cs.expectedStr, actualStr) {
+				inExpectedResult = true
 			}
 			c.Assert(inExpectedResult, check.IsTrue)
 		}

--- a/IceFireDB-SQLProxy/utils/util.go
+++ b/IceFireDB-SQLProxy/utils/util.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"runtime/debug"
+	"slices"
 	"strconv"
 	"time"
 
@@ -15,12 +16,7 @@ import (
 )
 
 func InArray(in string, array []string) bool {
-	for k := range array {
-		if in == array[k] {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(array, in)
 }
 
 func GoWithRecover(handler func(), recoverHandler func(r interface{})) {

--- a/IceFireDB-SQLite/pkg/mysql/mysql/mariadb_gtid_test.go
+++ b/IceFireDB-SQLite/pkg/mysql/mysql/mariadb_gtid_test.go
@@ -2,6 +2,7 @@ package mysql
 
 import (
 	"github.com/pingcap/check"
+	"slices"
 )
 
 type mariaDBTestSuite struct{}
@@ -128,11 +129,8 @@ func (t *mariaDBTestSuite) TestParseMariaDBGTIDSet(c *check.C) {
 			// check String() function
 			inExpectedResult := false
 			actualStr := mariadbGTIDSet.String()
-			for _, str := range cs.expectedStr {
-				if str == actualStr {
-					inExpectedResult = true
-					break
-				}
+			if slices.Contains(cs.expectedStr, actualStr) {
+				inExpectedResult = true
 			}
 			c.Assert(inExpectedResult, check.IsTrue)
 		}

--- a/IceFireDB-SQLite/utils/util.go
+++ b/IceFireDB-SQLite/utils/util.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"runtime/debug"
+	"slices"
 	"strconv"
 	"time"
 
@@ -15,12 +16,7 @@ import (
 )
 
 func InArray(in string, array []string) bool {
-	for k := range array {
-		if in == array[k] {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(array, in)
 }
 
 func GoWithRecover(handler func(), recoverHandler func(r interface{})) {


### PR DESCRIPTION
There is a [new function](https://pkg.go.dev/slices@go1.21.0#Contains) added in the go1.21 standard library, which can make the code more concise and easy to read.